### PR TITLE
Fix cell reuse bug

### DIFF
--- a/restaurant-list/ViewControllers/Cells/MainTableViewCell.swift
+++ b/restaurant-list/ViewControllers/Cells/MainTableViewCell.swift
@@ -21,8 +21,10 @@ class MainTableViewCell: UITableViewCell {
             addressLabel.text = "\(restaurant?.address.street ?? ""), \(restaurant?.address.locality ?? ""), \(restaurant?.address.country ?? "")"
             isFavorite ? favoriteButton.setImage(UIImage(named: "filled-heart"), for: .normal) : favoriteButton.setImage(UIImage(named: "empty-heart"), for: .normal)
             if let icon = restaurant?.mainPhoto?.squareImage {
+                iconImageView.backgroundColor = nil
                 iconImageView.setImageFromString(stringUrl: icon)
             } else {
+                iconImageView.image = nil
                 iconImageView.backgroundColor = .secondarySystemFill
             }
             ratingLabel.text = "The fork: \(restaurant?.aggregateRatings.thefork.ratingValue ?? 0) - TripAdvisor: \(restaurant?.aggregateRatings.tripadvisor.ratingValue ?? 0)"
@@ -112,6 +114,12 @@ class MainTableViewCell: UITableViewCell {
         favoriteButton.heightAnchor.constraint(equalTo: favoriteButton.widthAnchor, multiplier: 1/1).isActive = true
         favoriteButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: Constants.Constraints.trailingAnchor).isActive = true
         favoriteButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        iconImageView.image = nil
+        iconImageView.backgroundColor = .secondarySystemFill
     }
     
     @objc func buttonTapped(_ sender : Any) {

--- a/restaurant-listTests/MainTableViewCellTests.swift
+++ b/restaurant-listTests/MainTableViewCellTests.swift
@@ -28,6 +28,13 @@ class ImportedMapsPageTableViewCellTests: XCTestCase {
         XCTAssertEqual(delegate.isFavoriteSelected, true)
     }
 
+    func test_prepareForReuseClearsImage() {
+        // Simulate an image already set from a previous restaurant
+        subject.iconImageView.image = UIImage()
+        subject.prepareForReuse()
+        XCTAssertNil(subject.iconImageView.image)
+    }
+
     private func getTestViewData() -> MainViewControllerData {
         let restaurant = Restaurant(name: "Test", uuid: "123312", servesCuisine: "arg", priceRange: 122, currenciesAccepted: "USD", address: Address(street: "yada yada", postalCode: "12123", locality: "arg", country: "arg"), mainPhoto: nil, aggregateRatings: AggregateRatings(thefork: TheforkRatings(ratingValue: 10, reviewCount: 10), tripadvisor: TripadvisorRatings(ratingValue: 10, reviewCount: 10)), bestOffer: BestOffer(name: "122", label: "offer"))
         return MainViewControllerData(restaurants: [restaurant])


### PR DESCRIPTION
## Summary
- avoid showing stale images when cells are reused
- clear previous image in `prepareForReuse`
- test that reuse clears the image

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683f86fd2c808329bc6ad429b2c40278