### PR TITLE
Fix memory leak in image loading

### DIFF
--- a/Utilities/UIImageViewExtension.swift
+++ b/Utilities/UIImageViewExtension.swift
@@ -13,7 +13,8 @@ extension UIImageView {
     func setImageFromString(stringUrl: String) {
         if let url = URL(string: stringUrl) {
             
-        URLSession.shared.dataTask(with: url) { (data, response, error) in
+        URLSession.shared.dataTask(with: url) { [weak self] (data, response, error) in
+          guard let self = self else { return }
           guard let imageData = data else { return }
           DispatchQueue.main.async {
             self.image = UIImage(data: imageData)


### PR DESCRIPTION
## Summary
- capture UIImageView weakly when loading images

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f882239a08329bdd5de59318a8597